### PR TITLE
TLS 1.3 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,30 +4,12 @@
 /coverage/
 /InstalledFiles
 /pkg/
-/spec/reports/
-/spec/examples.txt
 /test/tmp/
 /test/version_tmp/
 /tmp/
 
 # Used by dotenv library to load environment variables.
 # .env
-
-## Specific to RubyMotion:
-.dat*
-.repl_history
-build/
-*.bridgesupport
-build-iPhoneOS/
-build-iPhoneSimulator/
-
-## Specific to RubyMotion (use of CocoaPods):
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# vendor/Pods/
 
 ## Documentation cache and generated files:
 /.yardoc/
@@ -42,9 +24,9 @@ build-iPhoneSimulator/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
+Gemfile.lock
+.ruby-version
+.ruby-gemset
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
@@ -52,3 +34,15 @@ build-iPhoneSimulator/
 .vagrant
 Vagrantfile
 *.log
+
+# If we're using Docker, ignore these:
+# or .local/share/pry/pry_history if you need to be more exact
+.local/
+.irb_history
+.byebug_history
+# For Debian images with Bash
+.bash_history
+# For Alpine images
+.ash_history
+
+vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,3 @@ desc "Run tests"
 task default: :test
 
 require "bundler/gem_tasks"
-require "chandler/tasks"
-
-# Add chandler as a prerequisite for `rake release`
-task "release:rubygem_push": "chandler:push"

--- a/lib/shared_infrastructure/nginx/listen.rb
+++ b/lib/shared_infrastructure/nginx/listen.rb
@@ -43,7 +43,7 @@ module Nginx
         "# Optimize TLS, from: https://www.bjornjohansen.no/optimizing-https-nginx, steps 1-3",
         "ssl_session_cache shared:SSL:1m; # Enough for 4,000 sessions.",
         "ssl_session_timeout 180m;",
-        "ssl_protocols TLSv1 TLSv1.1 TLSv1.2;",
+        "ssl_protocols TLSv1.3 TLSv1.2;",
         "ssl_prefer_server_ciphers on;",
         "ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;",
         "# Step 4",

--- a/lib/shared_infrastructure/version.rb
+++ b/lib/shared_infrastructure/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SharedInfrastructure
-  VERSION = "2.1.2"
+  VERSION = "2.2.0"
 end

--- a/shared-infrastructure.gemspec
+++ b/shared-infrastructure.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |s|
     "bin/create-reverse-proxy",
     "bin/create-server-block"
   ]
-  s.add_development_dependency "chandler"
   s.executables.concat(%w[
                          create-server-block
                          create-rails-app

--- a/test/test.rb
+++ b/test/test.rb
@@ -81,7 +81,7 @@ class Test < MiniTest::Test
   # Optimize TLS, from: https://www.bjornjohansen.no/optimizing-https-nginx, steps 1-3
   ssl_session_cache shared:SSL:1m; # Enough for 4,000 sessions.
   ssl_session_timeout 180m;
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.3 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
   # Step 4
@@ -131,7 +131,7 @@ server {
   # Optimize TLS, from: https://www.bjornjohansen.no/optimizing-https-nginx, steps 1-3
   ssl_session_cache shared:SSL:1m; # Enough for 4,000 sessions.
   ssl_session_timeout 180m;
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.3 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
   # Step 4
@@ -289,7 +289,7 @@ server {
   # Optimize TLS, from: https://www.bjornjohansen.no/optimizing-https-nginx, steps 1-3
   ssl_session_cache shared:SSL:1m; # Enough for 4,000 sessions.
   ssl_session_timeout 180m;
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.3 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
   # Step 4
@@ -365,7 +365,7 @@ server {
   # Optimize TLS, from: https://www.bjornjohansen.no/optimizing-https-nginx, steps 1-3
   ssl_session_cache shared:SSL:1m; # Enough for 4,000 sessions.
   ssl_session_timeout 180m;
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.3 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
   # Step 4
@@ -429,7 +429,7 @@ server {
   # Optimize TLS, from: https://www.bjornjohansen.no/optimizing-https-nginx, steps 1-3
   ssl_session_cache shared:SSL:1m; # Enough for 4,000 sessions.
   ssl_session_timeout 180m;
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.3 TLSv1.2;
   ssl_prefer_server_ciphers on;
   ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5;
   # Step 4
@@ -491,7 +491,7 @@ server {
         # Foreground process (do not use --daemon in ExecStart or config.rb)
         Type=simple
 
-        User=ubuntu
+        User=#{Etc.getlogin}
         Group=www-data
 
         # Specify the path to the Rails application root
@@ -506,8 +506,8 @@ server {
         # The command to start Puma
         # NOTE: TLS would be handled by Nginx
         ExecStart=/tmp/builder_test/var/www/#{domain}/html/bin/puma -b unix:///tmp/#{domain}.sock \
-              --redirect-stdout=/tmp/builder_test/var/www/#{domain}/html/log/puma-#{rails_env}.stdout.log \
-              --redirect-stderr=/tmp/builder_test/var/www/#{domain}/html/log/puma-#{rails_env}.stderr.log
+          --redirect-stdout=/tmp/builder_test/var/www/#{domain}/html/log/puma-#{rails_env}.stdout.log \
+          --redirect-stderr=/tmp/builder_test/var/www/#{domain}/html/log/puma-#{rails_env}.stderr.log
         # ExecStart=/usr/local/bin/puma -b tcp://unix:///tmp/#{domain}.sock
 
         Restart=always


### PR DESCRIPTION
Drop TLS 1.0 and 1.1 and add TLS 1.3.

Note that Nginx on Ubuntu 18.04 doesn't support TLS 1.3.